### PR TITLE
Only support 64bit

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,5 @@
 name: sublime-text-3
 version: '3143'
-version-script: |
-  python3 -c "import urllib.request; print(urllib.request.urlopen(\"https://download.sublimetext.com/latest/stable\").read().decode().strip())"
 summary: A sophisticated text editor for code, markup and prose.
 description: |
   A sophisticated text editor for code, markup and prose.
@@ -10,7 +8,6 @@ grade: stable
 confinement: classic
 architectures:
   - amd64
-  - i386
 
 apps:
   sublime-text-3:


### PR DESCRIPTION
While we are building for 32bit, it won't work as the binaries that we are downloading from upstream are 64bit code.

If we want to support 32bit release, then we need to write a custom plugin that fetches different tarball based on the arch.