### PR TITLE
Change app name to subl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,6 +6,8 @@ description: |
 
 grade: stable
 confinement: classic
+architectures:
+  - amd64
 
 apps:
   subl:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,11 +6,9 @@ description: |
 
 grade: stable
 confinement: classic
-architectures:
-  - amd64
 
 apps:
-  sublime-text-3:
+  subl:
     command: sublime_text
     desktop: sublime_text.desktop
 


### PR DESCRIPTION
Upstream only has a single entry point `subl`. So we rename our app to `subl` and at the same time get an alias added for it to the store.

Discussion here https://forum.snapcraft.io/t/requesting-subl-auto-alias/3674