### PR TITLE
Remove '3' from snap name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <h1 align="center">
-  <img src="https://avatars1.githubusercontent.com/u/684879?s=200&v=4&s=256" alt="Sublime Text 3">
+  <img src="https://avatars1.githubusercontent.com/u/684879?s=200&v=4&s=256" alt="Sublime Text">
   <br />
-  Sublime Text 3
+  Sublime Text
 </h1>
 
 
-<p align="center"><b>This is the snap for Sublime Text 3</b>, <i>"A sophisticated text editor for code, markup and prose"</i>. It works on Ubuntu, Fedora, Debian, and other major Linux
+<p align="center"><b>This is the snap for Sublime Text</b>, <i>"A sophisticated text editor for code, markup and prose"</i>. It works on Ubuntu, Fedora, Debian, and other major Linux
 distributions.</p>
 
 <!-- Uncomment and modify this when you are provided a build status badge
@@ -16,7 +16,7 @@ distributions.</p>
 
 ## Install
 
-    sudo snap install sublime-text-3 --classic
+    sudo snap install sublime-text --classic
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 
@@ -31,7 +31,7 @@ distributions.</p>
 Snapcrafters ([join us](https://forum.snapcraft.io/t/join-snapcrafters/1325)) 
 are working to land snap install documentation and
 the [snapcraft.yaml](https://github.com/snapcrafters/fork-and-rename-me/blob/master/snap/snapcraft.yaml)
-upstream so Sublime Text 3 can authoritatively publish future releases.
+upstream so Sublime Text can authoritatively publish future releases.
 
   - [x] Fork the [Snapcrafters template](https://github.com/snapcrafters/fork-and-rename-me) repository to your own GitHub account.
     - If you have already forked the Snapcrafter template to your account and want to create another snap, you'll need to use GitHub's [Import repository](https://github.com/new/import) feature because you can only fork a repository once.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ architectures:
   - amd64
 
 apps:
-  sublime-text:
+  subl:
     command: sublime_text
     desktop: sublime_text.desktop
 
@@ -20,5 +20,3 @@ parts:
     source: https://download.sublimetext.com/sublime_text_3_build_$SNAPCRAFT_PROJECT_VERSION_x64.tar.bz2
     install: |
       sed -i 's|Icon=.*|Icon=/Icon/256x256/sublime-text.png|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
-    stage-packages:
-      - libc6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: sublime-text-3
+name: sublime-text
 version: '3143'
 summary: A sophisticated text editor for code, markup and prose.
 description: |
@@ -10,13 +10,15 @@ architectures:
   - amd64
 
 apps:
-  sublime-text-3:
+  sublime-text:
     command: sublime_text
     desktop: sublime_text.desktop
 
 parts:
-  sublime-text-3:
+  sublime-text:
     plugin: dump
     source: https://download.sublimetext.com/sublime_text_3_build_$SNAPCRAFT_PROJECT_VERSION_x64.tar.bz2
     install: |
-      sed -i 's|Icon=.*|Icon=/Icon/48x48/sublime-text.png|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
+      sed -i 's|Icon=.*|Icon=/Icon/256x256/sublime-text.png|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
+    stage-packages:
+      - libc6


### PR DESCRIPTION
Rename `sublime-text-3` to `sublime-text`. By default it will point to version 3 and we'll create a new track for version 2.