### PR TITLE
Bundle gtk2 with snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,3 +20,7 @@ parts:
     source: https://download.sublimetext.com/sublime_text_3_build_$SNAPCRAFT_PROJECT_VERSION_x64.tar.bz2
     install: |
       sed -i 's|Icon=.*|Icon=/Icon/256x256/sublime-text.png|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
+      sed -i 's|/opt/sublime_text/sublime_text|'"$SNAP"'/sublime_text|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
+    stage-packages:
+      - libgtk2.0-0
+      - libc6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ parts:
     source: https://download.sublimetext.com/sublime_text_3_build_$SNAPCRAFT_PROJECT_VERSION_x64.tar.bz2
     install: |
       sed -i 's|Icon=.*|Icon=/Icon/256x256/sublime-text.png|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
-      sed -i 's|/opt/sublime_text/sublime_text|/snap/bin/sublime-text.subl|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
+      sed -i 's|/opt/sublime_text/sublime_text|sublime_text|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
     stage-packages:
       - libgtk2.0-0
       - libc6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ parts:
     source: https://download.sublimetext.com/sublime_text_3_build_$SNAPCRAFT_PROJECT_VERSION_x64.tar.bz2
     install: |
       sed -i 's|Icon=.*|Icon=/Icon/256x256/sublime-text.png|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
-      sed -i 's|/opt/sublime_text/sublime_text|'"$SNAP"'/sublime_text|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
+      sed -i 's|/opt/sublime_text/sublime_text|/snap/bin/sublime-text.subl|g' $SNAPCRAFT_PART_INSTALL/sublime_text.desktop
     stage-packages:
       - libgtk2.0-0
       - libc6


### PR DESCRIPTION
Due to latest changes somewhere in the stack (snapd?), my classic snap is not able to link to system wide installed libraries hence causing sublime-text not to start, if we ship the requirements with the snap the issue is resolved.