### PR TITLE
Remove architectures stanza as it breaks auto builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,8 +6,6 @@ description: |
 
 grade: stable
 confinement: classic
-architectures:
-  - amd64
 
 apps:
   subl:


### PR DESCRIPTION
Currently a snap built on armhf or i386 server would ship armhf/i386 libc and gtk with our snap, causing sublime-text to not start at all.

By removing the architectures stanza, we produce builds with "correct" dependencies.

Note: this snap won't work on armhf/i386 so we will only release to amd64.