### PR TITLE
Use Sublime Text's dev channel by default

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,9 +18,10 @@ parts:
     plugin: nil
     override-build: |
       snapcraftctl build
-      # Get the latest release
-      echo "Get latest release..."
-      wget --quiet https://download.sublimetext.com/latest/stable -O release.txt
+      # Get the latest release ("dev" by default, change to "stable" when required)
+      SUBLIME_CHANNEL=dev
+      echo "Getting the latest ${SUBLIME_CHANNEL} release build number..."
+      wget --quiet https://download.sublimetext.com/latest/${SUBLIME_CHANNEL} -O release.txt
       VERSION=$(cat release.txt)
       echo $VERSION > $SNAPCRAFT_STAGE/version
       rm -f release.txt 2>/dev/null


### PR DESCRIPTION
First attempt at #14 

Hey guys, I'm keen to get [Sublime Text's dev channel](https://www.sublimetext.com/3dev) available via this snap. At the moment we are tied to the stable releases (https://www.sublimetext.com/3) which come out once every few months, whereas their dev channel has much more frequent updates.

I'm not too familiar with Snaps/Snapcraft yet, but I'd hope there's a good way to make use of Snap Channels (stable, candidate, beta, edge) rather than publishing another Snap called sublime-text-dev. There may be a better way of handling this, but the way I see this working would be something like:

### Dev releases
1. Set the SUBLIME_CHANNEL to "dev" by default now
2. Trigger a build when a new tar package is published by ST in their dev channel (Are the builds currently triggered by new commits and manually? A daily timer would be nice here but I don't have access to the job config on https://build.snapcraft.io/user/snapcrafters/sublime-text)
2. When a build happens on https://build.snapcraft.io/user/snapcrafters/sublime-text/ the resulting snap should already go to the edge channel automatically I believe?
3. Users (with a ST license) install with `sudo snap install sublime-text --edge` (or get snap auto updates for free)

### Stable releases
1. Change the SUBLIME_CHANNEL to "stable" in snap/snapcraft.yaml
2. Trigger a build with a 'release commit' (e.g. git commit -m "v3.1 stable release"). Other options could include env vars depending on how the build is configured at https://build.snapcraft.io/user/snapcrafters/sublime-text.
3. Publish the snap from that build to the stable Snap channel (e.g. snapcraft release sublime-text 13 stable)
4. Revert the SUBLIME_CHANNEL to "dev" in snap/snapcraft.yaml so the daily dev builds can resume to go to the edge Snap channel.

Another option for the stable release workflow could be branching? Maintaining SUBLIME_CHANNEL="dev" on the master branch and only changing it to "stable" on a branch/tag (never merged)

Let me know what you guys think!

Cheers,
Kyle
