### PR TITLE
Use LZO compression

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,7 @@ architectures:
 
 grade: stable
 confinement: classic
+compression: lzo
 
 apps:
   subl:


### PR DESCRIPTION
This enables the use of LZO compression for the sublime-text snap