### PR TITLE
chore: Bump version to 4166

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sublime-text
-version: '4152'
+version: '4166'
 summary: A sophisticated text editor for code, markup and prose.
 title: Sublime Text
 description: |


### PR DESCRIPTION
There's a new upstream release. This bumps the snap to the new version.