### PR TITLE
Fix: Add libmd0 to resolve #47

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,7 @@ parts:
       # Desktop Action are not Unity specific.
       sed -i 's|OnlyShowIn|#OnlyShowIn|g' $CRAFT_PART_INSTALL/usr/share/applications/sublime_text.desktop
     stage-packages:
+      - libmd0
       - libbsd0
       - libffi7
       - libgtk-3-0


### PR DESCRIPTION
This stages `libmd0` which is required by Sublime text 4166 and fixes #47 