### PR TITLE
Chore: Update to 4169

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sublime-text
-version: '4166'
+version: '4169'
 summary: A sophisticated text editor for code, markup and prose.
 title: Sublime Text
 description: |


### PR DESCRIPTION
There's an upstream release:

BUILD 4169
24 November 2023
* Fixed a stack overflow when closing large amounts of files
* API: Fixed backwards compatibility breakage with Sheet.is_transient()
* API: Fixed a crash with Window.set_view_index
* Linux: Fixed a rare crash with the save dialog
* Windows: Fixed a rare crash related to cursor hiding