### PR TITLE
ci: ensure that the `subl` app is used for screenshots

### DIFF
--- a/.github/workflows/release-to-candidate.yml
+++ b/.github/workflows/release-to-candidate.yml
@@ -71,3 +71,4 @@ jobs:
           issue-number: ${{ needs.call-for-testing.outputs.issue-number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           screenshots-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+          snap-application-name: subl


### PR DESCRIPTION
See (and merge after): https://github.com/snapcrafters/ci/pull/32