### PR TITLE
ci: prepare for promotion/PRs on seperate branches

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -9,17 +9,37 @@ permissions:
   issues: write
 
 jobs:
-  promote:
-    name: ⬆️ Promote to stable
+  promote-latest:
+    name: ⬆️ Promote to latest/stable
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
     if: |
       ( !github.event.issue.pull_request )
       && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.comment.body, 'latest/stable')
+      && contains(github.event.issue.body, 'latest/stable')
       && contains(github.event.*.labels.*.name, 'testing')
     steps:
-      - name: ⬆️ Promote to stable
+      - name: ⬆️ Promote to latest/stable
         uses: snapcrafters/ci/promote-to-stable@main
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE_STABLE }}
+
+  promote-dev:
+    name: ⬆️ Promote to dev/stable
+    environment: "Dev Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.comment.body, 'dev/stable')
+      && contains(github.event.issue.body, 'dev/stable')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - name: ⬆️ Promote to dev/stable
+        uses: snapcrafters/ci/promote-to-stable@main
+        with:
+          channel: dev/stable
           github-token: ${{ secrets.GITHUB_TOKEN }}
           store-token: ${{ secrets.SNAP_STORE_STABLE }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: ["**"]
+    branches: ["candidate"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Part 2 of #61.

Workflows can only be triggered by issues on the default branch, so this adds similar handling as in `gimp` so that the automation can discern the difference between promoting to `latest/candidate` and `dev/candidate`.